### PR TITLE
Fix null handling in RevolutService

### DIFF
--- a/src/main/java/com/investment/metal/service/RevolutService.java
+++ b/src/main/java/com/investment/metal/service/RevolutService.java
@@ -51,6 +51,7 @@ public class RevolutService extends AbstractService {
     }
 
     public double getRevolutProfitFor(MetalType metalType) {
-        return revolutRepository.findByMetalSymbol(metalType.getSymbol()).getProfit();
+        RevolutProfit profit = revolutRepository.findByMetalSymbol(metalType.getSymbol());
+        return profit != null ? profit.getProfit() : 0d;
     }
 }


### PR DESCRIPTION
## Summary
- prevent NPE when Revolut profit data doesn't exist

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6866d47095cc832faf549fdf61420b35