### PR TITLE
Add charset encryption test

### DIFF
--- a/src/test/java/com/investment/metal/encryption/AESEncryptorTest.java
+++ b/src/test/java/com/investment/metal/encryption/AESEncryptorTest.java
@@ -1,0 +1,21 @@
+package com.investment.metal.encryption;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AESEncryptorTest {
+
+    @Test
+    public void encryptDecryptShouldPreserveStringWithCharset() {
+        AESEncryptor encryptor = new AESEncryptor(StandardCharsets.UTF_8);
+        encryptor.setKey(AbstractHandShakeEncryptor.AES_KEY_HANDSHAKE);
+        String original = "Привет, мир!"; // contains non-ASCII characters
+        String encrypted = encryptor.encrypt(original);
+        assertNotNull(encrypted);
+        String decrypted = encryptor.decrypt(encrypted);
+        assertEquals(original, decrypted);
+    }
+}


### PR DESCRIPTION
## Summary
- add AESEncryptorTest with non-ASCII text

## Testing
- `mvn -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Dhttps.protocols=TLSv1.2 test`

------
https://chatgpt.com/codex/tasks/task_e_68674ea8ffc8832fb94be6ca097764ac