### PR TITLE
Migrate to JDK 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:22-jdk-slim
 VOLUME /tmp
 COPY /target/metal-investment-0.0.1.jar app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # metal-investment
+
+**Requires JDK 22 to build and run**
 <div>
 <div dir="auto">
 <p>This project is for Revolut users from Romania who invested in gold, silver or platinum.<br />The project is monitoring the precious metals price at Bloomberg/Galmarley, and it's using some formula to approximate the metal price at Revolut. If the price of the metal is so high so your profit would match a logical expression that you provided, then the application would notify you by email. Also the users could check whenever they want their profit by calling an API. The project is in developing phase.</p>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<description>Investment in precious metals</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+                <java.version>22</java.version>
 	</properties>
 
 	<dependencies>
@@ -146,31 +146,39 @@
 	</dependencies>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<addResources>true</addResources>
-					<profiles>
-						<profile>dev</profile>
-						<profile>prod</profile>
-					</profiles>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>repackage</goal>
-						</goals>
-						<configuration>
-							<mainClass>
-								com.investment.metal.MetalApplication
-							</mainClass>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.11.0</version>
+                                <configuration>
+                                        <release>${java.version}</release>
+                                </configuration>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                                <configuration>
+                                        <addResources>true</addResources>
+                                        <profiles>
+                                                <profile>dev</profile>
+                                                <profile>prod</profile>
+                                        </profiles>
+                                </configuration>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>repackage</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <mainClass>
+                                                                com.investment.metal.MetalApplication
+                                                        </mainClass>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>


### PR DESCRIPTION
## Summary
- bump required Java version to 22
- configure `maven-compiler-plugin` to compile with JDK 22
- use JDK 22 Docker base image
- document the new Java requirement

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686758acdd80832fb0b9447a25784a1c