### PR TITLE
Fix self injection in ExceptionService

### DIFF
--- a/src/main/java/com/investment/metal/service/exception/ExceptionService.java
+++ b/src/main/java/com/investment/metal/service/exception/ExceptionService.java
@@ -2,19 +2,25 @@ package com.investment.metal.service.exception;
 
 import com.investment.metal.MessageKey;
 import com.investment.metal.exceptions.BusinessException;
-import com.investment.metal.service.AbstractService;
+import com.investment.metal.service.MessageService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 
 @Service
-public class ExceptionService extends AbstractService {
+public class ExceptionService {
 
+    private final MessageService messageService;
     private ExceptionBuilder exceptionBuilder;
+
+    @Autowired
+    public ExceptionService(MessageService messageService) {
+        this.messageService = messageService;
+    }
 
     @PostConstruct
     public void init() {
-        this.exceptionService = null;
         this.exceptionBuilder = new ExceptionBuilder();
     }
 


### PR DESCRIPTION
## Summary
- refactor `ExceptionService` to stop extending `AbstractService`
- inject `MessageService` via constructor
- initialize exception builder independently

## Testing
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68675893f0a4832fa8cd933de2bea800