### PR TITLE
Use Maven base image to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,7 @@
 #ENTRYPOINT ["java", "-jar", "/app.jar"]
 #
 # Multi-stage build for Spring Boot application
-FROM openjdk:9-jdk-slim AS build
-
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y maven \
-    && rm -rf /var/lib/apt/lists/*
+FROM maven:3.9.6-eclipse-temurin-17 AS build
 
 WORKDIR /app
 
@@ -21,7 +17,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # Runtime stage
-FROM openjdk:9-jre-slim
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
 	<name>metal</name>
 	<description>Investment in precious metals</description>
 
-        <properties>
-                <java.version>9</java.version>
-        </properties>
+  <properties>
+      <java.version>17</java.version>
+  </properties>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Summary
- switch the build stage to the official Maven + Temurin image so Maven is preinstalled
- update the runtime stage to the matching Temurin JRE image to avoid Debian SID key issues

## Testing
- mvn test *(fails: interrupted after prolonged dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68e968b830d4832fb32a5ffdb4b2dd2c