### PR TITLE
Allow unauthenticated access to Swagger endpoints

### DIFF
--- a/src/main/java/com/investment/metal/config/Config.java
+++ b/src/main/java/com/investment/metal/config/Config.java
@@ -221,7 +221,24 @@ public class Config implements WebMvcConfigurer {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return (web) -> web.ignoring().requestMatchers("/token/**");
+    return (web) -> web.ignoring().requestMatchers(
+        "/token/**",
+        "/swagger-ui",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/swagger-ui.html/**",
+        "/swagger-ui/index.html",
+        "/swagger-ui/index.html/**",
+        "/swagger-resources",
+        "/swagger-resources/**",
+        "/v3/api-docs",
+        "/v3/api-docs/**",
+        "/v3/api-docs.yaml",
+        "/v3/api-docs.yaml/**",
+        "/api-docs",
+        "/api-docs/**",
+        "/webjars/**"
+    );
   }
 
   @Bean


### PR DESCRIPTION
## Summary
- allow Spring Security to completely ignore Swagger UI and OpenAPI documentation routes so they remain publicly accessible
- ensure Cloud Run deployment no longer returns 403 responses for /v3/api-docs and related assets

## Testing
- mvn -DskipTests package *(fails: Fatal error compiling: error: release version 22 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc984d744832fac9c0bfe02fb0748