### PR TITLE
Refine scheduler design

### DIFF
--- a/src/main/java/com/investment/metal/common/RSSFeedParser.java
+++ b/src/main/java/com/investment/metal/common/RSSFeedParser.java
@@ -8,10 +8,12 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
+@Component
 public class RSSFeedParser {
 
   public Map<CurrencyType, Double> readFeed(String feedUrl) throws IOException {


### PR DESCRIPTION
## Summary
- refactor the scheduler to use constructor injection and update all metals each run
- register the RSS feed parser as a Spring component and guard against missing currencies

## Testing
- ./mvnw -q -pl :metal-investment-backend test *(fails: network unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68edf94143c4832f87fc0b5229ca1599